### PR TITLE
fix: agent run background will receive suspended (tty output)

### DIFF
--- a/agent/handler/shell.go
+++ b/agent/handler/shell.go
@@ -66,6 +66,8 @@ func (shell *Shell) start() {
 		if runtime.GOARCH == "386" || runtime.GOARCH == "amd64" {
 			cmd = exec.Command("/bin/bash", "-i")
 		}
+		cmd.SysProcAttr = &syscall.SysProcAttr{Foreground: true}
+		signal.Ignore(syscall.SIGTTIN, syscall.SIGTTOU)
 	}
 
 	shell.stdout, err = cmd.StdoutPipe()


### PR DESCRIPTION
when agent run background with & will break by signal  bash will receive message suspended (tty output)。so ignore syscall signal and set command run Foreground