### PR TITLE
优化 shell 交互体验，增加 PTY/ConPTY 支持

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -1,4 +1,5 @@
 //go:build !windows
+// +build !windows
 
 package main
 
@@ -26,13 +27,16 @@ func init() {
 func main() {
 	printer.InitPrinter()
 
-	termbox.Init()
+	options := initial.ParseOptions()
+
+	if err := termbox.Init(); err != nil {
+		printer.Fail("[*] Failed to initialize terminal: %s\r\n", err.Error())
+		os.Exit(1)
+	}
 	termbox.SetCursor(0, 0)
 	termbox.Flush()
 
 	go listenCtrlC()
-
-	options := initial.ParseOptions()
 
 	cli.Banner()
 

--- a/admin/admin_win.go
+++ b/admin/admin_win.go
@@ -1,4 +1,5 @@
 //go:build windows
+// +build windows
 
 package main
 

--- a/admin/cli/cli.go
+++ b/admin/cli/cli.go
@@ -48,7 +48,8 @@ func ShowNodeHelp() {
 	addmemo    <string>                             Add memo for current node
 	delmemo                                         Delete memo of current node
 	ssh        <ip:port>                            Start SSH through current node
-	shell                                           Start an interactive shell on current node
+	shell                                           Start terminal stream if supported, otherwise legacy shell
+	legacy_shell                                    Start the original line-based shell on current node
 	socks      <lport> [username] [pass]            Start a socks5 server
 	stopsocks                                       Shut down socks services
 	connect    <ip:port>                            Connect to a new node

--- a/admin/cli/helper.go
+++ b/admin/cli/helper.go
@@ -50,6 +50,7 @@ func NewHelper() *Helper {
 		"delmemo",
 		"ssh",
 		"shell",
+		"legacy_shell",
 		"socks",
 		"sshtunnel",
 		"connect",
@@ -66,7 +67,7 @@ func NewHelper() *Helper {
 	}
 
 	helper.min = 0
-	helper.max = 11
+	helper.max = 12
 
 	helper.adminTree = new(tireTree)
 	helper.adminTree.root = new(tireNode)
@@ -185,7 +186,7 @@ func (helper *Helper) getSuffix(node *tireNode, suffix *[]string, tSuffix string
 
 	if len(node.children) != 0 {
 		for char := range node.children {
-			ttSuffix := tSuffix + string(char)
+			ttSuffix := tSuffix + string(rune(char))
 			tNode := node.children[char]
 			helper.getSuffix(tNode, suffix, ttSuffix)
 		}

--- a/admin/cli/interactive.go
+++ b/admin/cli/interactive.go
@@ -1,4 +1,5 @@
 //go:build !windows
+// +build !windows
 
 package cli
 
@@ -577,20 +578,43 @@ func (console *Console) handleNodePanelCommand(uuidNum int) {
 				break
 			}
 
-			printer.Warning("\r\n[*] Waiting for response.....")
-
-			handler.LetShellStart(route, uuid)
-
-			if <-console.mgr.ConsoleManager.OK {
-				console.status = ""
-				console.shellMode = true
-				console.handleShellPanelCommand(route, uuid)
-				console.shellMode = false
-				console.status = fmt.Sprintf("(node %d) >> ", uuidNum)
+			console.shellMode = true
+			prompt := fmt.Sprintf("(node %d) >> ", uuidNum)
+			supportsTerminal := console.supportTerminal(uuidNum)
+			if supportsTerminal {
+				console.status = prompt
+				printer.Warning("\r\n[*] Starting terminal stream.....")
+				console.handleTerminalPanelCommand(route, uuid)
 			} else {
-				printer.Fail("\r\n[*] Shell cannot be started!")
-				console.ready <- true
+				console.status = ""
+				printer.Warning("\r\n[*] Target does not advertise terminal stream support, starting legacy shell.....")
+				if console.startLegacyShell(route, uuid) {
+					fmt.Print("\r\n")
+				}
 			}
+			console.shellMode = false
+			console.status = prompt
+			if !supportsTerminal {
+				fmt.Print(console.status)
+			}
+		case "legacy_shell":
+			if !console.isOnline(uuidNum) {
+				return
+			}
+
+			if console.expectParams(fCommand, 1, NODE, 0) {
+				break
+			}
+
+			printer.Warning("\r\n[*] Starting legacy shell.....")
+			console.status = ""
+			console.shellMode = true
+			if console.startLegacyShell(route, uuid) {
+				fmt.Print("\r\n")
+			}
+			console.shellMode = false
+			console.status = fmt.Sprintf("(node %d) >> ", uuidNum)
+			fmt.Print(console.status)
 		case "listen":
 			if !console.isOnline(uuidNum) {
 				return
@@ -1078,6 +1102,9 @@ func (console *Console) handleShellPanelCommand(route string, uuid string) {
 			}
 			protocol.ConstructMessage(sMessage, header, shellCommandMess, false)
 			sMessage.SendMessage()
+			if isLegacyShellExit(tCommand) {
+				return
+			}
 		case <-console.mgr.ConsoleManager.Exit:
 			return
 		}
@@ -1206,4 +1233,15 @@ func (console *Console) isOnline(uuidNum int) bool {
 
 	printer.Fail("\r\n[*] Node %d seems offline!", uuidNum)
 	return false
+}
+
+func (console *Console) supportTerminal(uuidNum int) bool {
+	task := &topology.TopoTask{
+		Mode:    topology.CHECKTERMINAL,
+		UUIDNum: uuidNum,
+	}
+	console.topology.TaskChan <- task
+
+	result := <-console.topology.ResultChan
+	return result.IsExist && result.SupportTerminal
 }

--- a/admin/cli/interactive_win.go
+++ b/admin/cli/interactive_win.go
@@ -1,4 +1,5 @@
 //go:build windows
+// +build windows
 
 package cli
 
@@ -589,20 +590,43 @@ func (console *Console) handleNodePanelCommand(uuidNum int) {
 				break
 			}
 
-			printer.Warning("\r\n[*] Waiting for response.....")
-
-			handler.LetShellStart(route, uuid)
-
-			if <-console.mgr.ConsoleManager.OK {
-				console.status = ""
-				console.shellMode = true
-				console.handleShellPanelCommand(route, uuid)
-				console.shellMode = false
-				console.status = fmt.Sprintf("(node %d) >> ", uuidNum)
+			console.shellMode = true
+			prompt := fmt.Sprintf("(node %d) >> ", uuidNum)
+			supportsTerminal := console.supportTerminal(uuidNum)
+			if supportsTerminal {
+				console.status = prompt
+				printer.Warning("\r\n[*] Starting terminal stream.....")
+				console.handleTerminalPanelCommand(route, uuid)
 			} else {
-				printer.Fail("\r\n[*] Shell cannot be started!")
-				console.ready <- true
+				console.status = ""
+				printer.Warning("\r\n[*] Target does not advertise terminal stream support, starting legacy shell.....")
+				if console.startLegacyShell(route, uuid) {
+					fmt.Print("\r\n")
+				}
 			}
+			console.shellMode = false
+			console.status = prompt
+			if !supportsTerminal {
+				fmt.Print(console.status)
+			}
+		case "legacy_shell":
+			if !console.isOnline(uuidNum) {
+				return
+			}
+
+			if console.expectParams(fCommand, 1, NODE, 0) {
+				break
+			}
+
+			printer.Warning("\r\n[*] Starting legacy shell.....")
+			console.status = ""
+			console.shellMode = true
+			if console.startLegacyShell(route, uuid) {
+				fmt.Print("\r\n")
+			}
+			console.shellMode = false
+			console.status = fmt.Sprintf("(node %d) >> ", uuidNum)
+			fmt.Print(console.status)
 		case "listen":
 			if !console.isOnline(uuidNum) {
 				return
@@ -1090,6 +1114,9 @@ func (console *Console) handleShellPanelCommand(route string, uuid string) {
 			}
 			protocol.ConstructMessage(sMessage, header, shellCommandMess, false)
 			sMessage.SendMessage()
+			if isLegacyShellExit(tCommand) {
+				return
+			}
 		case <-console.mgr.ConsoleManager.Exit:
 			return
 		}
@@ -1218,4 +1245,15 @@ func (console *Console) isOnline(uuidNum int) bool {
 
 	printer.Fail("\r\n[*] Node %d seems offline!", uuidNum)
 	return false
+}
+
+func (console *Console) supportTerminal(uuidNum int) bool {
+	task := &topology.TopoTask{
+		Mode:    topology.CHECKTERMINAL,
+		UUIDNum: uuidNum,
+	}
+	console.topology.TaskChan <- task
+
+	result := <-console.topology.ResultChan
+	return result.IsExist && result.SupportTerminal
 }

--- a/admin/cli/terminal_fallback.go
+++ b/admin/cli/terminal_fallback.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"Stowaway/admin/handler"
+	"Stowaway/admin/printer"
+)
+
+func (console *Console) fallbackLegacyShell(route string, uuid string) bool {
+	printer.Warning("\r\n[*] Terminal Stream unavailable, falling back to legacy shell.....")
+	status := console.status
+	console.status = ""
+	ok := console.startLegacyShell(route, uuid)
+	console.status = status
+	if ok {
+		fmt.Print("\r\n")
+		fmt.Print(console.status)
+	}
+	return ok
+}
+
+func (console *Console) startLegacyShell(route string, uuid string) bool {
+	drainConsoleExit(console)
+	handler.LetShellStart(route, uuid)
+	ok, timedOut := console.waitConsoleOK(10 * time.Second)
+	if timedOut {
+		printer.Fail("\r\n[*] Legacy shell start timed out!")
+		console.ready <- true
+		return false
+	}
+	if !ok {
+		printer.Fail("\r\n[*] Legacy shell cannot be started!")
+		console.ready <- true
+		return false
+	}
+	console.handleShellPanelCommand(route, uuid)
+	return true
+}
+
+func drainConsoleExit(console *Console) {
+	for {
+		select {
+		case <-console.mgr.ConsoleManager.Exit:
+		default:
+			return
+		}
+	}
+}
+
+func (console *Console) waitConsoleOK(timeout time.Duration) (bool, bool) {
+	select {
+	case ok := <-console.mgr.ConsoleManager.OK:
+		return ok, false
+	case <-time.After(timeout):
+		return false, true
+	}
+}
+
+func isLegacyShellExit(command string) bool {
+	fields := strings.Fields(command)
+	if len(fields) == 0 {
+		return false
+	}
+	return fields[0] == "exit" || fields[0] == "logout"
+}

--- a/admin/cli/terminal_termios_bsd.go
+++ b/admin/cli/terminal_termios_bsd.go
@@ -1,0 +1,14 @@
+//go:build darwin || freebsd
+// +build darwin freebsd
+
+package cli
+
+import "golang.org/x/sys/unix"
+
+func ioctlReadTermios() uint {
+	return unix.TIOCGETA
+}
+
+func ioctlWriteTermios() uint {
+	return unix.TIOCSETA
+}

--- a/admin/cli/terminal_termios_linux.go
+++ b/admin/cli/terminal_termios_linux.go
@@ -1,0 +1,14 @@
+//go:build linux
+// +build linux
+
+package cli
+
+import "golang.org/x/sys/unix"
+
+func ioctlReadTermios() uint {
+	return unix.TCGETS
+}
+
+func ioctlWriteTermios() uint {
+	return unix.TCSETS
+}

--- a/admin/cli/terminal_unix.go
+++ b/admin/cli/terminal_unix.go
@@ -1,0 +1,186 @@
+//go:build !windows
+// +build !windows
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"Stowaway/admin/handler"
+	"Stowaway/admin/printer"
+
+	"github.com/nsf/termbox-go"
+	"golang.org/x/sys/unix"
+)
+
+func (console *Console) handleTerminalPanelCommand(route string, uuid string) {
+	session := handler.NewTerminalSession()
+	drainConsoleExit(console)
+	handler.SetActiveTerminalSession(session)
+	waiter := handler.RegisterTerminalWaiter(session)
+	finish := func() {
+		handler.ClearActiveTerminalSession(session)
+		handler.UnregisterTerminalWaiter(session)
+		console.ready <- true
+	}
+
+	cols, rows := currentTerminalSize()
+	handler.LetTerminalStart(route, uuid, session, cols, rows)
+
+	ok, timedOut := waiter.WaitReady(10 * time.Second)
+	if timedOut {
+		printer.Fail("\r\n[*] Terminal start timed out!")
+		handler.SendTerminalExit(route, uuid, session)
+		finish()
+		return
+	}
+	if !ok {
+		handler.ClearActiveTerminalSession(session)
+		handler.UnregisterTerminalWaiter(session)
+		console.fallbackLegacyShell(route, uuid)
+		return
+	}
+
+	termbox.Close()
+
+	restore, err := makeRaw(int(os.Stdin.Fd()))
+	if err != nil {
+		printer.Fail("\r\n[*] Unable to switch local terminal to raw mode: %s", err.Error())
+		handler.SendTerminalExit(route, uuid, session)
+		restoreTermbox()
+		finish()
+		return
+	}
+
+	done := make(chan struct{})
+	localExit := make(chan struct{}, 1)
+	go forwardLocalInput(route, uuid, session, done, localExit)
+	go forwardTerminalResize(route, uuid, session, done)
+
+	select {
+	case <-waiter.Exit:
+	case <-localExit:
+		handler.SendTerminalExit(route, uuid, session)
+	}
+	close(done)
+	restore()
+	restoreTermbox()
+	finish()
+}
+
+func forwardLocalInput(route string, uuid string, session uint64, done <-chan struct{}, localExit chan<- struct{}) {
+	buf := make([]byte, 4096)
+	for {
+		select {
+		case <-done:
+			return
+		default:
+		}
+
+		n, err := os.Stdin.Read(buf)
+		if n > 0 {
+			data := append([]byte(nil), buf[:n]...)
+			if pos := controlBackslashIndex(data); pos >= 0 {
+				if pos > 0 {
+					handler.SendTerminalData(route, uuid, session, data[:pos])
+				}
+				select {
+				case localExit <- struct{}{}:
+				default:
+				}
+				return
+			}
+			handler.SendTerminalData(route, uuid, session, data)
+		}
+		if errors.Is(err, unix.EAGAIN) || errors.Is(err, unix.EWOULDBLOCK) {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		if err != nil {
+			select {
+			case localExit <- struct{}{}:
+			default:
+			}
+			return
+		}
+	}
+}
+
+func forwardTerminalResize(route string, uuid string, session uint64, done <-chan struct{}) {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGWINCH)
+	defer signal.Stop(sigCh)
+
+	cols, rows := currentTerminalSize()
+	handler.SendTerminalResize(route, uuid, session, cols, rows)
+	for {
+		select {
+		case <-done:
+			return
+		case <-sigCh:
+			cols, rows := currentTerminalSize()
+			handler.SendTerminalResize(route, uuid, session, cols, rows)
+		}
+	}
+}
+
+func controlBackslashIndex(data []byte) int {
+	for i, b := range data {
+		if b == 0x1c {
+			return i
+		}
+	}
+	return -1
+}
+
+func makeRaw(fd int) (func(), error) {
+	oldState, err := unix.IoctlGetTermios(fd, ioctlReadTermios())
+	if err != nil {
+		return nil, err
+	}
+	oldFlags, err := unix.FcntlInt(uintptr(fd), unix.F_GETFL, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	newState := *oldState
+	newState.Iflag &^= unix.BRKINT | unix.ICRNL | unix.INPCK | unix.ISTRIP | unix.IXON
+	newState.Oflag &^= unix.OPOST
+	newState.Cflag |= unix.CS8
+	newState.Lflag &^= unix.ECHO | unix.ICANON | unix.IEXTEN | unix.ISIG
+	newState.Cc[unix.VMIN] = 1
+	newState.Cc[unix.VTIME] = 0
+
+	if err := unix.IoctlSetTermios(fd, ioctlWriteTermios(), &newState); err != nil {
+		return nil, err
+	}
+	if _, err := unix.FcntlInt(uintptr(fd), unix.F_SETFL, oldFlags|unix.O_NONBLOCK); err != nil {
+		_ = unix.IoctlSetTermios(fd, ioctlWriteTermios(), oldState)
+		return nil, err
+	}
+
+	return func() {
+		_, _ = unix.FcntlInt(uintptr(fd), unix.F_SETFL, oldFlags)
+		_ = unix.IoctlSetTermios(fd, ioctlWriteTermios(), oldState)
+	}, nil
+}
+
+func currentTerminalSize() (uint16, uint16) {
+	ws, err := unix.IoctlGetWinsize(int(os.Stdout.Fd()), unix.TIOCGWINSZ)
+	if err != nil || ws.Col == 0 || ws.Row == 0 {
+		return 80, 24
+	}
+	return ws.Col, ws.Row
+}
+
+func restoreTermbox() {
+	if err := termbox.Init(); err != nil {
+		return
+	}
+	termbox.SetCursor(0, 0)
+	termbox.Flush()
+}

--- a/admin/cli/terminal_windows.go
+++ b/admin/cli/terminal_windows.go
@@ -1,0 +1,116 @@
+//go:build windows
+// +build windows
+
+package cli
+
+import (
+	"time"
+
+	"Stowaway/admin/handler"
+	"Stowaway/admin/printer"
+
+	"github.com/eiannone/keyboard"
+)
+
+func (console *Console) handleTerminalPanelCommand(route string, uuid string) {
+	session := handler.NewTerminalSession()
+	drainConsoleExit(console)
+	handler.SetActiveTerminalSession(session)
+	waiter := handler.RegisterTerminalWaiter(session)
+	finish := func() {
+		handler.ClearActiveTerminalSession(session)
+		handler.UnregisterTerminalWaiter(session)
+		console.ready <- true
+	}
+
+	handler.LetTerminalStart(route, uuid, session, 80, 24)
+
+	ok, timedOut := waiter.WaitReady(10 * time.Second)
+	if timedOut {
+		printer.Fail("\r\n[*] Terminal start timed out!")
+		handler.SendTerminalExit(route, uuid, session)
+		finish()
+		return
+	}
+	if !ok {
+		handler.ClearActiveTerminalSession(session)
+		handler.UnregisterTerminalWaiter(session)
+		console.fallbackLegacyShell(route, uuid)
+		return
+	}
+
+	keysEvents, err := keyboard.GetKeys(10)
+	if err != nil {
+		printer.Fail("\r\n[*] Unable to read local keyboard: %s", err.Error())
+		handler.SendTerminalExit(route, uuid, session)
+		finish()
+		return
+	}
+
+	for {
+		select {
+		case event := <-keysEvents:
+			if event.Err != nil {
+				continue
+			}
+			if event.Key == keyboard.KeyCtrlBackslash {
+				handler.SendTerminalExit(route, uuid, session)
+				finish()
+				return
+			}
+			data := windowsKeyEventBytes(event)
+			if len(data) > 0 {
+				handler.SendTerminalData(route, uuid, session, data)
+			}
+		case <-waiter.Exit:
+			finish()
+			return
+		}
+	}
+}
+
+func windowsKeyEventBytes(event keyboard.KeyEvent) []byte {
+	if event.Rune != 0 {
+		return []byte(string(event.Rune))
+	}
+
+	switch event.Key {
+	case keyboard.KeyEnter:
+		return []byte{'\r'}
+	case keyboard.KeySpace:
+		return []byte{' '}
+	case keyboard.KeyTab:
+		return []byte{'\t'}
+	case keyboard.KeyBackspace, keyboard.KeyBackspace2:
+		return []byte{0x08}
+	case keyboard.KeyEsc:
+		return []byte{0x1b}
+	case keyboard.KeyArrowUp:
+		return []byte{0x1b, '[', 'A'}
+	case keyboard.KeyArrowDown:
+		return []byte{0x1b, '[', 'B'}
+	case keyboard.KeyArrowRight:
+		return []byte{0x1b, '[', 'C'}
+	case keyboard.KeyArrowLeft:
+		return []byte{0x1b, '[', 'D'}
+	case keyboard.KeyHome:
+		return []byte{0x1b, '[', 'H'}
+	case keyboard.KeyEnd:
+		return []byte{0x1b, '[', 'F'}
+	case keyboard.KeyDelete:
+		return []byte{0x1b, '[', '3', '~'}
+	case keyboard.KeyPgup:
+		return []byte{0x1b, '[', '5', '~'}
+	case keyboard.KeyPgdn:
+		return []byte{0x1b, '[', '6', '~'}
+	}
+
+	if event.Key > 0 && event.Key < keyboard.KeySpace {
+		return []byte{byte(event.Key)}
+	}
+	if event.Key == keyboard.KeyCtrlSpace {
+		return []byte{0}
+	}
+
+	return nil
+}

--- a/admin/handler/memo.go
+++ b/admin/handler/memo.go
@@ -1,12 +1,16 @@
 package handler
 
 import (
+	"strings"
+
 	"Stowaway/admin/manager"
 	"Stowaway/admin/printer"
 	"Stowaway/admin/topology"
 	"Stowaway/global"
 	"Stowaway/protocol"
 )
+
+const terminalCapabilityMemoMark = "\x00stowaway-terminal-stream-v1"
 
 func AddMemo(taskChan chan *topology.TopoTask, info []string, uuid string, route string) {
 	var memo string
@@ -78,14 +82,23 @@ func DispatchInfoMess(mgr *manager.Manager, topo *topology.Topology) {
 
 		switch mess := message.(type) {
 		case *protocol.MyInfo:
+			memo, supportTerminal := parseNodeMemo(mess.Memo)
 			task := &topology.TopoTask{
 				Mode:     topology.UPDATEDETAIL,
 				UUID:     mess.UUID,
 				UserName: mess.Username,
 				HostName: mess.Hostname,
-				Memo:     mess.Memo,
+				Memo:     memo,
+				Terminal: supportTerminal,
 			}
 			topo.TaskChan <- task
 		}
 	}
+}
+
+func parseNodeMemo(memo string) (string, bool) {
+	if strings.HasSuffix(memo, terminalCapabilityMemoMark) {
+		return strings.TrimSuffix(memo, terminalCapabilityMemoMark), true
+	}
+	return memo, false
 }

--- a/admin/handler/terminal.go
+++ b/admin/handler/terminal.go
@@ -1,0 +1,238 @@
+package handler
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"Stowaway/admin/manager"
+	"Stowaway/global"
+	"Stowaway/protocol"
+)
+
+var terminalSession = struct {
+	sync.RWMutex
+	id uint64
+}{}
+
+var terminalSessionCounter uint64
+
+type TerminalWaiter struct {
+	Session uint64
+	Ready   chan bool
+	Exit    chan struct{}
+}
+
+var terminalWaiters = struct {
+	sync.Mutex
+	items map[uint64]*TerminalWaiter
+}{
+	items: make(map[uint64]*TerminalWaiter),
+}
+
+func NewTerminalSession() uint64 {
+	session := uint64(time.Now().UnixNano()) ^ atomic.AddUint64(&terminalSessionCounter, 1)
+	if session == 0 {
+		session = atomic.AddUint64(&terminalSessionCounter, 1)
+	}
+	return session
+}
+
+func SetActiveTerminalSession(session uint64) {
+	terminalSession.Lock()
+	terminalSession.id = session
+	terminalSession.Unlock()
+}
+
+func ClearActiveTerminalSession(session uint64) {
+	terminalSession.Lock()
+	if terminalSession.id == session {
+		terminalSession.id = 0
+	}
+	terminalSession.Unlock()
+}
+
+func isActiveTerminalSession(session uint64) bool {
+	terminalSession.RLock()
+	defer terminalSession.RUnlock()
+	return terminalSession.id == session
+}
+
+func RegisterTerminalWaiter(session uint64) *TerminalWaiter {
+	waiter := &TerminalWaiter{
+		Session: session,
+		Ready:   make(chan bool, 1),
+		Exit:    make(chan struct{}, 1),
+	}
+	terminalWaiters.Lock()
+	terminalWaiters.items[session] = waiter
+	terminalWaiters.Unlock()
+	return waiter
+}
+
+func UnregisterTerminalWaiter(session uint64) {
+	terminalWaiters.Lock()
+	delete(terminalWaiters.items, session)
+	terminalWaiters.Unlock()
+}
+
+func (waiter *TerminalWaiter) WaitReady(timeout time.Duration) (bool, bool) {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case ok := <-waiter.Ready:
+		return ok, false
+	case <-timer.C:
+		return false, true
+	}
+}
+
+func LetTerminalStart(route string, uuid string, session uint64, cols, rows uint16) {
+	sMessage := protocol.NewDownMsg(global.G_Component.Conn, global.G_Component.Secret, global.G_Component.UUID)
+
+	header := &protocol.Header{
+		Sender:      protocol.ADMIN_UUID,
+		Accepter:    uuid,
+		MessageType: protocol.TERMINALSTART,
+		RouteLen:    uint32(len([]byte(route))),
+		Route:       route,
+	}
+
+	startMess := &protocol.TerminalStart{
+		Start:   1,
+		Session: session,
+		Cols:    cols,
+		Rows:    rows,
+	}
+
+	protocol.ConstructMessage(sMessage, header, startMess, false)
+	sMessage.SendMessage()
+}
+
+func SendTerminalData(route string, uuid string, session uint64, data []byte) {
+	if len(data) == 0 {
+		return
+	}
+
+	sMessage := protocol.NewDownMsg(global.G_Component.Conn, global.G_Component.Secret, global.G_Component.UUID)
+
+	header := &protocol.Header{
+		Sender:      protocol.ADMIN_UUID,
+		Accepter:    uuid,
+		MessageType: protocol.TERMINALDATA,
+		RouteLen:    uint32(len([]byte(route))),
+		Route:       route,
+	}
+
+	dataMess := &protocol.TerminalData{
+		Session: session,
+		DataLen: uint64(len(data)),
+		Data:    data,
+	}
+
+	protocol.ConstructMessage(sMessage, header, dataMess, false)
+	sMessage.SendMessage()
+}
+
+func SendTerminalResize(route string, uuid string, session uint64, cols, rows uint16) {
+	if cols == 0 || rows == 0 {
+		return
+	}
+
+	sMessage := protocol.NewDownMsg(global.G_Component.Conn, global.G_Component.Secret, global.G_Component.UUID)
+
+	header := &protocol.Header{
+		Sender:      protocol.ADMIN_UUID,
+		Accepter:    uuid,
+		MessageType: protocol.TERMINALRESIZE,
+		RouteLen:    uint32(len([]byte(route))),
+		Route:       route,
+	}
+
+	resizeMess := &protocol.TerminalResize{
+		Session: session,
+		Cols:    cols,
+		Rows:    rows,
+	}
+
+	protocol.ConstructMessage(sMessage, header, resizeMess, false)
+	sMessage.SendMessage()
+}
+
+func SendTerminalExit(route string, uuid string, session uint64) {
+	sMessage := protocol.NewDownMsg(global.G_Component.Conn, global.G_Component.Secret, global.G_Component.UUID)
+
+	header := &protocol.Header{
+		Sender:      protocol.ADMIN_UUID,
+		Accepter:    uuid,
+		MessageType: protocol.TERMINALEXIT,
+		RouteLen:    uint32(len([]byte(route))),
+		Route:       route,
+	}
+
+	exitMess := &protocol.TerminalExit{Session: session, OK: 1}
+	protocol.ConstructMessage(sMessage, header, exitMess, false)
+	sMessage.SendMessage()
+}
+
+func notifyTerminalReady(ready *protocol.TerminalReady) {
+	terminalWaiters.Lock()
+	waiter := terminalWaiters.items[ready.Session]
+	terminalWaiters.Unlock()
+	if waiter == nil {
+		return
+	}
+
+	select {
+	case waiter.Ready <- ready.OK == 1:
+	default:
+	}
+}
+
+func notifyTerminalExit(session uint64) {
+	terminalWaiters.Lock()
+	waiter := terminalWaiters.items[session]
+	terminalWaiters.Unlock()
+	if waiter == nil {
+		return
+	}
+
+	select {
+	case waiter.Exit <- struct{}{}:
+	default:
+	}
+}
+
+func DispatchTerminalMess(mgr *manager.Manager) {
+	for {
+		message := <-mgr.TerminalManager.TerminalMessChan
+
+		switch mess := message.(type) {
+		case *protocol.TerminalReady:
+			if !isActiveTerminalSession(mess.Session) {
+				continue
+			}
+			if mess.OK == 1 {
+				notifyTerminalReady(mess)
+			} else {
+				if mess.Error != "" {
+					fmt.Fprintf(os.Stderr, "\r\n[*] Terminal error: %s\r\n", mess.Error)
+				}
+				notifyTerminalReady(mess)
+			}
+		case *protocol.TerminalData:
+			if !isActiveTerminalSession(mess.Session) {
+				continue
+			}
+			_, _ = os.Stdout.Write(mess.Data)
+		case *protocol.TerminalExit:
+			if !isActiveTerminalSession(mess.Session) {
+				continue
+			}
+			notifyTerminalExit(mess.Session)
+		}
+	}
+}

--- a/admin/initial/parser.go
+++ b/admin/initial/parser.go
@@ -1,4 +1,5 @@
 //go:build !windows
+// +build !windows
 
 package initial
 

--- a/admin/initial/parser_win.go
+++ b/admin/initial/parser_win.go
@@ -1,4 +1,5 @@
 //go:build windows
+// +build windows
 
 package initial
 

--- a/admin/manager/manager.go
+++ b/admin/manager/manager.go
@@ -19,6 +19,7 @@ type Manager struct {
 	SSHManager       *sshManager
 	SSHTunnelManager *sshTunnelManager
 	ShellManager     *shellManager
+	TerminalManager  *terminalManager
 	InfoManager      *infoManager
 	ListenManager    *listenManager
 	ConnectManager   *connectManager
@@ -35,6 +36,7 @@ func NewManager(file *share.MyFile) *Manager {
 	manager.SSHManager = newSSHManager()
 	manager.SSHTunnelManager = newSSHTunnelManager()
 	manager.ShellManager = newShellManager()
+	manager.TerminalManager = newTerminalManager()
 	manager.InfoManager = newInfoManager()
 	manager.ListenManager = newListenManager()
 	manager.ConnectManager = newConnectManager()

--- a/admin/manager/others.go
+++ b/admin/manager/others.go
@@ -59,6 +59,16 @@ func newShellManager() *shellManager {
 	return manager
 }
 
+type terminalManager struct {
+	TerminalMessChan chan interface{}
+}
+
+func newTerminalManager() *terminalManager {
+	manager := new(terminalManager)
+	manager.TerminalMessChan = make(chan interface{}, 5)
+	return manager
+}
+
 type infoManager struct {
 	InfoMessChan chan interface{}
 }

--- a/admin/process/process.go
+++ b/admin/process/process.go
@@ -1,4 +1,5 @@
 //go:build !windows
+// +build !windows
 
 package process
 
@@ -49,6 +50,7 @@ func (admin *Admin) Run() {
 	go handler.DispatchSSHMess(admin.mgr)
 	go handler.DispatchSSHTunnelMess(admin.mgr)
 	go handler.DispatchShellMess(admin.mgr)
+	go handler.DispatchTerminalMess(admin.mgr)
 	go handler.DispatchInfoMess(admin.mgr, admin.topology)
 	go DispatchChildrenMess(admin.mgr, admin.topology)
 	// if options.Heartbeat is set, send a heartbeat packet to the agent
@@ -83,6 +85,12 @@ func (admin *Admin) handleMessFromDownstream(console *cli.Console) {
 			fallthrough
 		case protocol.SHELLEXIT:
 			admin.mgr.ShellManager.ShellMessChan <- message
+		case protocol.TERMINALREADY:
+			fallthrough
+		case protocol.TERMINALDATA:
+			fallthrough
+		case protocol.TERMINALEXIT:
+			admin.mgr.TerminalManager.TerminalMessChan <- message
 		case protocol.SSHRES:
 			fallthrough
 		case protocol.SSHRESULT:

--- a/admin/process/process_win.go
+++ b/admin/process/process_win.go
@@ -1,4 +1,5 @@
 //go:build windows
+// +build windows
 
 package process
 
@@ -47,6 +48,7 @@ func (admin *Admin) Run() {
 	go handler.DispatchSSHMess(admin.mgr)
 	go handler.DispatchSSHTunnelMess(admin.mgr)
 	go handler.DispatchShellMess(admin.mgr)
+	go handler.DispatchTerminalMess(admin.mgr)
 	go handler.DispatchInfoMess(admin.mgr, admin.topology)
 	go DispatchChildrenMess(admin.mgr, admin.topology)
 	// if options.Heartbeat set, send heartbeat packet to agent
@@ -76,6 +78,12 @@ func (admin *Admin) handleMessFromDownstream(console *cli.Console) {
 			fallthrough
 		case protocol.SHELLEXIT:
 			admin.mgr.ShellManager.ShellMessChan <- message
+		case protocol.TERMINALREADY:
+			fallthrough
+		case protocol.TERMINALDATA:
+			fallthrough
+		case protocol.TERMINALEXIT:
+			admin.mgr.TerminalManager.TerminalMessChan <- message
 		case protocol.SSHRES:
 			fallthrough
 		case protocol.SSHRESULT:

--- a/admin/topology/topology.go
+++ b/admin/topology/topology.go
@@ -15,6 +15,7 @@ const (
 	GETUUID
 	GETUUIDNUM
 	CHECKNODE
+	CHECKTERMINAL
 	CALCULATE
 	GETROUTE
 	DELNODE
@@ -45,6 +46,7 @@ type node struct {
 	currentHostname string
 	currentIP       string
 	memo            string
+	supportTerminal bool
 }
 
 type TopoTask struct {
@@ -56,15 +58,17 @@ type TopoTask struct {
 	HostName   string
 	UserName   string
 	Memo       string
+	Terminal   bool
 	IsFirst    bool
 }
 
 type topoResult struct {
-	IsExist  bool
-	UUID     string
-	Route    string
-	IDNum    int
-	AllNodes []string
+	IsExist         bool
+	SupportTerminal bool
+	UUID            string
+	Route           string
+	IDNum           int
+	AllNodes        []string
 }
 
 func NewTopology() *Topology {
@@ -97,6 +101,8 @@ func (topology *Topology) Run() {
 			topology.getUUIDNum(task)
 		case CHECKNODE:
 			topology.checkNode(task)
+		case CHECKTERMINAL:
+			topology.checkTerminal(task)
 		case UPDATEDETAIL:
 			topology.updateDetail(task)
 		case SHOWDETAIL:
@@ -141,6 +147,14 @@ func (topology *Topology) getUUIDNum(task *TopoTask) {
 func (topology *Topology) checkNode(task *TopoTask) {
 	if _, ok := topology.nodes[task.UUIDNum]; ok {
 		topology.ResultChan <- &topoResult{IsExist: true}
+	} else {
+		topology.ResultChan <- &topoResult{IsExist: false}
+	}
+}
+
+func (topology *Topology) checkTerminal(task *TopoTask) {
+	if node, ok := topology.nodes[task.UUIDNum]; ok {
+		topology.ResultChan <- &topoResult{IsExist: true, SupportTerminal: node.supportTerminal}
 	} else {
 		topology.ResultChan <- &topoResult{IsExist: false}
 	}
@@ -214,6 +228,7 @@ func (topology *Topology) updateDetail(task *TopoTask) {
 		topology.nodes[uuidNum].currentUser = task.UserName
 		topology.nodes[uuidNum].currentHostname = task.HostName
 		topology.nodes[uuidNum].memo = task.Memo
+		topology.nodes[uuidNum].supportTerminal = task.Terminal
 	}
 }
 

--- a/agent/handler/terminal.go
+++ b/agent/handler/terminal.go
@@ -1,0 +1,231 @@
+//go:build !windows
+// +build !windows
+
+package handler
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"runtime"
+	"sync"
+
+	"Stowaway/agent/manager"
+	"Stowaway/global"
+	"Stowaway/protocol"
+
+	"github.com/creack/pty"
+)
+
+type Terminal struct {
+	session uint64
+	ptmx    *os.File
+	cmd     *exec.Cmd
+	mu      sync.Mutex
+	closed  bool
+}
+
+func newTerminal(session uint64) *Terminal {
+	return &Terminal{session: session}
+}
+
+func (terminal *Terminal) start(cols, rows uint16) {
+	var err error
+
+	readyHeader := &protocol.Header{
+		Sender:      global.G_Component.UUID,
+		Accepter:    protocol.ADMIN_UUID,
+		MessageType: protocol.TERMINALREADY,
+		RouteLen:    uint32(len([]byte(protocol.TEMP_ROUTE))),
+		Route:       protocol.TEMP_ROUTE,
+	}
+
+	dataHeader := &protocol.Header{
+		Sender:      global.G_Component.UUID,
+		Accepter:    protocol.ADMIN_UUID,
+		MessageType: protocol.TERMINALDATA,
+		RouteLen:    uint32(len([]byte(protocol.TEMP_ROUTE))),
+		Route:       protocol.TEMP_ROUTE,
+	}
+
+	exitHeader := &protocol.Header{
+		Sender:      global.G_Component.UUID,
+		Accepter:    protocol.ADMIN_UUID,
+		MessageType: protocol.TERMINALEXIT,
+		RouteLen:    uint32(len([]byte(protocol.TEMP_ROUTE))),
+		Route:       protocol.TEMP_ROUTE,
+	}
+
+	var sendMu sync.Mutex
+	send := func(header *protocol.Header, mess interface{}) {
+		sendMu.Lock()
+		defer sendMu.Unlock()
+		sMessage := protocol.NewUpMsg(global.G_Component.Conn, global.G_Component.Secret, global.G_Component.UUID)
+		protocol.ConstructMessage(sMessage, header, mess, false)
+		sMessage.SendMessage()
+	}
+
+	defer func() {
+		if err != nil {
+			ready := &protocol.TerminalReady{
+				Session:  terminal.session,
+				OK:       0,
+				ErrorLen: uint64(len(err.Error())),
+				Error:    err.Error(),
+			}
+			send(readyHeader, ready)
+		}
+	}()
+
+	cmd := exec.Command(defaultTerminalShell(), "-i")
+	cmd.Env = append(os.Environ(), "TERM=xterm-256color")
+	terminal.mu.Lock()
+	if terminal.closed {
+		terminal.mu.Unlock()
+		err = errors.New("terminal closed")
+		return
+	}
+	terminal.cmd = cmd
+	terminal.mu.Unlock()
+
+	ws := &pty.Winsize{Cols: cols, Rows: rows}
+	if ws.Cols == 0 {
+		ws.Cols = 80
+	}
+	if ws.Rows == 0 {
+		ws.Rows = 24
+	}
+
+	ptmx, err := pty.StartWithSize(cmd, ws)
+	if err != nil {
+		return
+	}
+	terminal.mu.Lock()
+	if terminal.closed {
+		terminal.mu.Unlock()
+		_ = ptmx.Close()
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		err = errors.New("terminal closed")
+		return
+	}
+	terminal.ptmx = ptmx
+	terminal.mu.Unlock()
+
+	ready := &protocol.TerminalReady{Session: terminal.session, OK: 1}
+	send(readyHeader, ready)
+
+	go func() {
+		_ = cmd.Wait()
+		terminal.close()
+		exit := &protocol.TerminalExit{Session: terminal.session, OK: 1}
+		send(exitHeader, exit)
+	}()
+
+	buf := make([]byte, 4096)
+	for {
+		terminal.mu.Lock()
+		ptmx := terminal.ptmx
+		closed := terminal.closed
+		terminal.mu.Unlock()
+		if closed || ptmx == nil {
+			return
+		}
+
+		n, readErr := ptmx.Read(buf)
+		if n > 0 {
+			data := append([]byte(nil), buf[:n]...)
+			dataMess := &protocol.TerminalData{
+				Session: terminal.session,
+				DataLen: uint64(len(data)),
+				Data:    data,
+			}
+			send(dataHeader, dataMess)
+		}
+		if readErr != nil {
+			return
+		}
+	}
+}
+
+func defaultTerminalShell() string {
+	if shell := os.Getenv("SHELL"); shell != "" {
+		return shell
+	}
+	if runtime.GOOS == "darwin" {
+		return "/bin/zsh"
+	}
+	if _, err := os.Stat("/bin/bash"); err == nil {
+		return "/bin/bash"
+	}
+	return "/bin/sh"
+}
+
+func (terminal *Terminal) input(data []byte) {
+	terminal.mu.Lock()
+	ptmx := terminal.ptmx
+	closed := terminal.closed
+	terminal.mu.Unlock()
+	if !closed && ptmx != nil {
+		_, _ = ptmx.Write(data)
+	}
+}
+
+func (terminal *Terminal) resize(cols, rows uint16) {
+	terminal.mu.Lock()
+	ptmx := terminal.ptmx
+	closed := terminal.closed
+	terminal.mu.Unlock()
+	if closed || ptmx == nil || cols == 0 || rows == 0 {
+		return
+	}
+	_ = pty.Setsize(ptmx, &pty.Winsize{Cols: cols, Rows: rows})
+}
+
+func (terminal *Terminal) close() {
+	terminal.mu.Lock()
+	terminal.closed = true
+	ptmx := terminal.ptmx
+	cmd := terminal.cmd
+	terminal.ptmx = nil
+	terminal.cmd = nil
+	terminal.mu.Unlock()
+
+	if ptmx != nil {
+		_ = ptmx.Close()
+	}
+	if cmd != nil && cmd.Process != nil {
+		_ = cmd.Process.Kill()
+	}
+}
+
+func DispatchTerminalMess(mgr *manager.Manager) {
+	var terminal *Terminal
+
+	for {
+		message := <-mgr.TerminalManager.TerminalMessChan
+
+		switch mess := message.(type) {
+		case *protocol.TerminalStart:
+			if terminal != nil {
+				terminal.close()
+			}
+			terminal = newTerminal(mess.Session)
+			go terminal.start(mess.Cols, mess.Rows)
+		case *protocol.TerminalData:
+			if terminal != nil && terminal.session == mess.Session {
+				terminal.input(mess.Data)
+			}
+		case *protocol.TerminalResize:
+			if terminal != nil && terminal.session == mess.Session {
+				terminal.resize(mess.Cols, mess.Rows)
+			}
+		case *protocol.TerminalExit:
+			if terminal != nil && terminal.session == mess.Session {
+				terminal.close()
+				terminal = nil
+			}
+		}
+	}
+}

--- a/agent/handler/terminal_windows.go
+++ b/agent/handler/terminal_windows.go
@@ -1,0 +1,473 @@
+//go:build windows
+// +build windows
+
+package handler
+
+import (
+	"errors"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+	"syscall"
+	"unsafe"
+
+	"Stowaway/agent/manager"
+	"Stowaway/global"
+	"Stowaway/protocol"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	procThreadAttributePseudoConsole = 0x00020016
+)
+
+var (
+	kernel32                          = syscall.NewLazyDLL("kernel32.dll")
+	procCreatePseudoConsole           = kernel32.NewProc("CreatePseudoConsole")
+	procResizePseudoConsole           = kernel32.NewProc("ResizePseudoConsole")
+	procClosePseudoConsole            = kernel32.NewProc("ClosePseudoConsole")
+	procInitializeProcThreadAttrList  = kernel32.NewProc("InitializeProcThreadAttributeList")
+	procUpdateProcThreadAttribute     = kernel32.NewProc("UpdateProcThreadAttribute")
+	procDeleteProcThreadAttributeList = kernel32.NewProc("DeleteProcThreadAttributeList")
+)
+
+type coord struct {
+	X int16
+	Y int16
+}
+
+type startupInfoEx struct {
+	windows.StartupInfo
+	AttributeList *byte
+}
+
+type windowsTerminal struct {
+	session    uint64
+	hpc        uintptr
+	inputWrite windows.Handle
+	outputRead windows.Handle
+	process    windows.ProcessInformation
+	sendMu     sync.Mutex
+	writeMu    sync.Mutex
+	closeMu    sync.Mutex
+	closed     bool
+}
+
+func newWindowsTerminal(session uint64) *windowsTerminal {
+	return &windowsTerminal{session: session}
+}
+
+func (terminal *windowsTerminal) start(cols, rows uint16) {
+	var err error
+
+	readyHeader := &protocol.Header{
+		Sender:      global.G_Component.UUID,
+		Accepter:    protocol.ADMIN_UUID,
+		MessageType: protocol.TERMINALREADY,
+		RouteLen:    uint32(len([]byte(protocol.TEMP_ROUTE))),
+		Route:       protocol.TEMP_ROUTE,
+	}
+
+	dataHeader := &protocol.Header{
+		Sender:      global.G_Component.UUID,
+		Accepter:    protocol.ADMIN_UUID,
+		MessageType: protocol.TERMINALDATA,
+		RouteLen:    uint32(len([]byte(protocol.TEMP_ROUTE))),
+		Route:       protocol.TEMP_ROUTE,
+	}
+
+	exitHeader := &protocol.Header{
+		Sender:      global.G_Component.UUID,
+		Accepter:    protocol.ADMIN_UUID,
+		MessageType: protocol.TERMINALEXIT,
+		RouteLen:    uint32(len([]byte(protocol.TEMP_ROUTE))),
+		Route:       protocol.TEMP_ROUTE,
+	}
+
+	send := func(header *protocol.Header, mess interface{}) {
+		terminal.sendMu.Lock()
+		defer terminal.sendMu.Unlock()
+		sMessage := protocol.NewUpMsg(global.G_Component.Conn, global.G_Component.Secret, global.G_Component.UUID)
+		protocol.ConstructMessage(sMessage, header, mess, false)
+		sMessage.SendMessage()
+	}
+
+	defer func() {
+		if err != nil {
+			ready := &protocol.TerminalReady{
+				Session:  terminal.session,
+				OK:       0,
+				ErrorLen: uint64(len(err.Error())),
+				Error:    err.Error(),
+			}
+			send(readyHeader, ready)
+			terminal.close()
+		}
+	}()
+
+	err = terminal.open(cols, rows)
+	if err != nil {
+		return
+	}
+	if terminal.isClosed() {
+		terminal.close()
+		return
+	}
+
+	cmdline, err := windows.UTF16PtrFromString(defaultWindowsShell())
+	if err != nil {
+		return
+	}
+
+	attrList, attrListPtr, err := newPseudoConsoleAttributeList(terminal.hpc)
+	if err != nil {
+		return
+	}
+	defer deleteProcThreadAttributeList(attrListPtr)
+
+	si := &startupInfoEx{AttributeList: attrListPtr}
+	si.StartupInfo.Cb = uint32(unsafe.Sizeof(*si))
+
+	err = windows.CreateProcess(
+		nil,
+		cmdline,
+		nil,
+		nil,
+		false,
+		windows.EXTENDED_STARTUPINFO_PRESENT|windows.CREATE_NO_WINDOW,
+		nil,
+		nil,
+		(*windows.StartupInfo)(unsafe.Pointer(si)),
+		&terminal.process,
+	)
+	runtime.KeepAlive(attrList)
+	if err != nil {
+		return
+	}
+
+	terminal.closeMu.Lock()
+	if terminal.closed {
+		process := terminal.process.Process
+		thread := terminal.process.Thread
+		terminal.process.Process = 0
+		terminal.process.Thread = 0
+		terminal.closeMu.Unlock()
+		if thread != 0 {
+			_ = windows.CloseHandle(thread)
+		}
+		if process != 0 {
+			_ = windows.TerminateProcess(process, 1)
+			_ = windows.CloseHandle(process)
+		}
+		terminal.close()
+		return
+	}
+	process := terminal.process.Process
+	thread := terminal.process.Thread
+	terminal.process.Thread = 0
+	terminal.closeMu.Unlock()
+
+	if thread != 0 {
+		_ = windows.CloseHandle(thread)
+	}
+
+	ready := &protocol.TerminalReady{Session: terminal.session, OK: 1}
+	send(readyHeader, ready)
+
+	go func() {
+		_, _ = windows.WaitForSingleObject(process, windows.INFINITE)
+		terminal.close()
+		exit := &protocol.TerminalExit{Session: terminal.session, OK: 1}
+		send(exitHeader, exit)
+	}()
+
+	buf := make([]byte, 4096)
+	for {
+		outputRead := terminal.outputReadHandle()
+		if outputRead == 0 {
+			return
+		}
+		var done uint32
+		readErr := windows.ReadFile(outputRead, buf, &done, nil)
+		if done > 0 {
+			data := append([]byte(nil), buf[:done]...)
+			dataMess := &protocol.TerminalData{
+				Session: terminal.session,
+				DataLen: uint64(len(data)),
+				Data:    data,
+			}
+			send(dataHeader, dataMess)
+		}
+		if readErr != nil {
+			return
+		}
+	}
+}
+
+func (terminal *windowsTerminal) open(cols, rows uint16) error {
+	if err := ensureConPTYAvailable(); err != nil {
+		return err
+	}
+	if cols == 0 {
+		cols = 80
+	}
+	if rows == 0 {
+		rows = 24
+	}
+
+	var inputRead, outputWrite windows.Handle
+	var inputWrite, outputRead windows.Handle
+	err := windows.CreatePipe(&inputRead, &inputWrite, nil, 0)
+	if err != nil {
+		return err
+	}
+	err = windows.CreatePipe(&outputRead, &outputWrite, nil, 0)
+	if err != nil {
+		_ = windows.CloseHandle(inputRead)
+		_ = windows.CloseHandle(inputWrite)
+		return err
+	}
+
+	var hpc uintptr
+	size := coord{X: int16(cols), Y: int16(rows)}
+	err = createPseudoConsole(size, inputRead, outputWrite, &hpc)
+	_ = windows.CloseHandle(inputRead)
+	_ = windows.CloseHandle(outputWrite)
+	if err != nil {
+		_ = windows.CloseHandle(inputWrite)
+		_ = windows.CloseHandle(outputRead)
+		return err
+	}
+
+	terminal.closeMu.Lock()
+	if terminal.closed {
+		terminal.closeMu.Unlock()
+		_ = windows.CloseHandle(inputWrite)
+		_ = windows.CloseHandle(outputRead)
+		closePseudoConsole(hpc)
+		return errors.New("terminal closed")
+	}
+	terminal.inputWrite = inputWrite
+	terminal.outputRead = outputRead
+	terminal.hpc = hpc
+	terminal.closeMu.Unlock()
+
+	return nil
+}
+
+func ensureConPTYAvailable() error {
+	if err := procCreatePseudoConsole.Find(); err != nil {
+		return errors.New("ConPTY unavailable: CreatePseudoConsole not found")
+	}
+	if err := procResizePseudoConsole.Find(); err != nil {
+		return errors.New("ConPTY unavailable: ResizePseudoConsole not found")
+	}
+	if err := procClosePseudoConsole.Find(); err != nil {
+		return errors.New("ConPTY unavailable: ClosePseudoConsole not found")
+	}
+	return nil
+}
+
+func defaultWindowsShell() string {
+	if shell := os.Getenv("ComSpec"); shell != "" {
+		return shell
+	}
+	return `C:\Windows\System32\cmd.exe`
+}
+
+func (terminal *windowsTerminal) input(data []byte) {
+	terminal.writeMu.Lock()
+	defer terminal.writeMu.Unlock()
+	inputWrite := terminal.inputWriteHandle()
+	if inputWrite == 0 || len(data) == 0 {
+		return
+	}
+	var done uint32
+	_ = windows.WriteFile(inputWrite, data, &done, nil)
+}
+
+func (terminal *windowsTerminal) resize(cols, rows uint16) {
+	hpc := terminal.pseudoConsoleHandle()
+	if hpc == 0 || cols == 0 || rows == 0 {
+		return
+	}
+	_ = resizePseudoConsole(hpc, coord{X: int16(cols), Y: int16(rows)})
+}
+
+func (terminal *windowsTerminal) close() {
+	terminal.closeMu.Lock()
+	terminal.closed = true
+	inputWrite := terminal.inputWrite
+	outputRead := terminal.outputRead
+	process := terminal.process.Process
+	thread := terminal.process.Thread
+	hpc := terminal.hpc
+	terminal.inputWrite = 0
+	terminal.outputRead = 0
+	terminal.process.Process = 0
+	terminal.process.Thread = 0
+	terminal.hpc = 0
+	terminal.closeMu.Unlock()
+
+	if process != 0 {
+		_ = windows.TerminateProcess(process, 1)
+	}
+	if inputWrite != 0 {
+		_ = windows.CloseHandle(inputWrite)
+	}
+	if outputRead != 0 {
+		_ = windows.CloseHandle(outputRead)
+	}
+	if process != 0 {
+		_ = windows.CloseHandle(process)
+	}
+	if thread != 0 {
+		_ = windows.CloseHandle(thread)
+	}
+	if hpc != 0 {
+		closePseudoConsole(hpc)
+	}
+}
+
+func (terminal *windowsTerminal) isClosed() bool {
+	terminal.closeMu.Lock()
+	defer terminal.closeMu.Unlock()
+	return terminal.closed
+}
+
+func (terminal *windowsTerminal) inputWriteHandle() windows.Handle {
+	terminal.closeMu.Lock()
+	defer terminal.closeMu.Unlock()
+	if terminal.closed {
+		return 0
+	}
+	return terminal.inputWrite
+}
+
+func (terminal *windowsTerminal) outputReadHandle() windows.Handle {
+	terminal.closeMu.Lock()
+	defer terminal.closeMu.Unlock()
+	if terminal.closed {
+		return 0
+	}
+	return terminal.outputRead
+}
+
+func (terminal *windowsTerminal) pseudoConsoleHandle() uintptr {
+	terminal.closeMu.Lock()
+	defer terminal.closeMu.Unlock()
+	if terminal.closed {
+		return 0
+	}
+	return terminal.hpc
+}
+
+func createPseudoConsole(size coord, input, output windows.Handle, hpc *uintptr) error {
+	r1, _, e1 := procCreatePseudoConsole.Call(
+		uintptr(*(*uint32)(unsafe.Pointer(&size))),
+		uintptr(input),
+		uintptr(output),
+		0,
+		uintptr(unsafe.Pointer(hpc)),
+	)
+	if r1 != 0 {
+		if e1 != syscall.Errno(0) {
+			return e1
+		}
+		return syscall.Errno(r1)
+	}
+	return nil
+}
+
+func resizePseudoConsole(hpc uintptr, size coord) error {
+	r1, _, e1 := procResizePseudoConsole.Call(
+		hpc,
+		uintptr(*(*uint32)(unsafe.Pointer(&size))),
+	)
+	if r1 != 0 {
+		if e1 != syscall.Errno(0) {
+			return e1
+		}
+		return syscall.Errno(r1)
+	}
+	return nil
+}
+
+func closePseudoConsole(hpc uintptr) {
+	procClosePseudoConsole.Call(hpc)
+}
+
+func newPseudoConsoleAttributeList(hpc uintptr) ([]byte, *byte, error) {
+	var size uintptr
+	r1, _, e1 := procInitializeProcThreadAttrList.Call(0, 1, 0, uintptr(unsafe.Pointer(&size)))
+	if r1 == 0 && size == 0 && e1 != syscall.Errno(0) {
+		return nil, nil, e1
+	}
+	if size == 0 {
+		return nil, nil, errors.New("empty proc thread attribute list")
+	}
+
+	attrList := make([]byte, size)
+	listPtr := &attrList[0]
+	r1, _, e1 = procInitializeProcThreadAttrList.Call(uintptr(unsafe.Pointer(listPtr)), 1, 0, uintptr(unsafe.Pointer(&size)))
+	if r1 == 0 {
+		return nil, nil, e1
+	}
+
+	r1, _, e1 = procUpdateProcThreadAttribute.Call(
+		uintptr(unsafe.Pointer(listPtr)),
+		0,
+		procThreadAttributePseudoConsole,
+		hpc,
+		unsafe.Sizeof(hpc),
+		0,
+		0,
+	)
+	if r1 == 0 {
+		deleteProcThreadAttributeList(listPtr)
+		return nil, nil, e1
+	}
+	return attrList, listPtr, nil
+}
+
+func deleteProcThreadAttributeList(attrList *byte) {
+	if attrList != nil {
+		procDeleteProcThreadAttributeList.Call(uintptr(unsafe.Pointer(attrList)))
+	}
+}
+
+func DispatchTerminalMess(mgr *manager.Manager) {
+	var terminal *windowsTerminal
+
+	for {
+		message := <-mgr.TerminalManager.TerminalMessChan
+
+		switch mess := message.(type) {
+		case *protocol.TerminalStart:
+			if terminal != nil {
+				terminal.close()
+			}
+			terminal = newWindowsTerminal(mess.Session)
+			go terminal.start(mess.Cols, mess.Rows)
+		case *protocol.TerminalData:
+			if terminal != nil && terminal.session == mess.Session {
+				terminal.input(normalizeWindowsTerminalInput(mess.Data))
+			}
+		case *protocol.TerminalResize:
+			if terminal != nil && terminal.session == mess.Session {
+				terminal.resize(mess.Cols, mess.Rows)
+			}
+		case *protocol.TerminalExit:
+			if terminal != nil && terminal.session == mess.Session {
+				terminal.close()
+				terminal = nil
+			}
+		}
+	}
+}
+
+func normalizeWindowsTerminalInput(data []byte) []byte {
+	return []byte(strings.ReplaceAll(string(data), "\n", "\r"))
+}

--- a/agent/manager/manager.go
+++ b/agent/manager/manager.go
@@ -13,6 +13,7 @@ type Manager struct {
 	SSHManager       *sshManager
 	SSHTunnelManager *sshTunnelManager
 	ShellManager     *shellManager
+	TerminalManager  *terminalManager
 	ListenManager    *listenManager
 	ConnectManager   *connectManager
 	OfflineManager   *offlineManager
@@ -28,6 +29,7 @@ func NewManager(file *share.MyFile) *Manager {
 	manager.SSHManager = newSSHManager()
 	manager.SSHTunnelManager = newSSHTunnelManager()
 	manager.ShellManager = newShellManager()
+	manager.TerminalManager = newTerminalManager()
 	manager.ListenManager = newListenManager()
 	manager.ConnectManager = newConnectManager()
 	manager.OfflineManager = newOfflineManager()

--- a/agent/manager/others.go
+++ b/agent/manager/others.go
@@ -45,6 +45,16 @@ func newShellManager() *shellManager {
 	return manager
 }
 
+type terminalManager struct {
+	TerminalMessChan chan interface{}
+}
+
+func newTerminalManager() *terminalManager {
+	manager := new(terminalManager)
+	manager.TerminalMessChan = make(chan interface{}, 5)
+	return manager
+}
+
 type listenManager struct {
 	ListenMessChan chan interface{}
 	ChildUUIDChan  chan string

--- a/agent/process/process.go
+++ b/agent/process/process.go
@@ -30,6 +30,8 @@ type ChildrenMess struct {
 	cMessage []byte
 }
 
+const terminalCapabilityMemoMark = "\x00stowaway-terminal-stream-v1"
+
 func NewAgent(options *initial.Options) *Agent {
 	agent := new(Agent)
 	agent.UUID = protocol.TEMP_UUID
@@ -53,6 +55,7 @@ func (agent *Agent) Run() {
 	go handler.DispatchSSHMess(agent.mgr)
 	go handler.DispatchSSHTunnelMess(agent.mgr)
 	go handler.DispatchShellMess(agent.mgr, agent.options)
+	go handler.DispatchTerminalMess(agent.mgr)
 	go DispatchOfflineMess(agent)
 	// run dispatcher to dispatch children's message
 	go agent.dispatchChildrenMess()
@@ -74,6 +77,7 @@ func (agent *Agent) sendMyInfo() {
 	}
 
 	hostname, username := utils.GetSystemInfo()
+	memo := agent.Memo + terminalCapabilityMemoMark
 
 	myInfoMess := &protocol.MyInfo{
 		UUIDLen:     uint16(len(agent.UUID)),
@@ -82,8 +86,8 @@ func (agent *Agent) sendMyInfo() {
 		Username:    username,
 		HostnameLen: uint64(len(hostname)),
 		Hostname:    hostname,
-		MemoLen:     uint64(len(agent.Memo)),
-		Memo:        agent.Memo,
+		MemoLen:     uint64(len(memo)),
+		Memo:        memo,
 	}
 
 	protocol.ConstructMessage(sMessage, header, myInfoMess, false)
@@ -112,6 +116,14 @@ func (agent *Agent) handleDataFromUpstream() {
 				fallthrough
 			case protocol.SHELLCOMMAND:
 				agent.mgr.ShellManager.ShellMessChan <- message
+			case protocol.TERMINALSTART:
+				fallthrough
+			case protocol.TERMINALDATA:
+				fallthrough
+			case protocol.TERMINALRESIZE:
+				fallthrough
+			case protocol.TERMINALEXIT:
+				agent.mgr.TerminalManager.TerminalMessChan <- message
 			case protocol.SSHREQ:
 				fallthrough
 			case protocol.SSHCOMMAND:

--- a/crypto/aes.go
+++ b/crypto/aes.go
@@ -41,6 +41,9 @@ func AESDecrypt(cryptedData, key []byte) []byte {
 	block, _ := aes.NewCipher(key)
 	gcm, _ := cipher.NewGCM(block)
 	nonceSize := gcm.NonceSize()
+	if len(cryptedData) < nonceSize {
+		return nil
+	}
 	nonce, cryptedData := cryptedData[:nonceSize], cryptedData[nonceSize:]
 	origData, _ := gcm.Open(nil, nonce, cryptedData, nil)
 	return origData

--- a/crypto/gzip.go
+++ b/crypto/gzip.go
@@ -3,8 +3,11 @@ package crypto
 import (
 	"bytes"
 	"compress/gzip"
+	"io"
 	"io/ioutil"
 )
+
+const maxDecompressedDataLen = 64 * 1024 * 1024
 
 // Thx to code from @lz520520
 func GzipCompress(src []byte) []byte {
@@ -23,8 +26,11 @@ func GzipDecompress(src []byte) []byte {
 		return dst
 	}
 	defer gr.Close()
-	tmp, err := ioutil.ReadAll(gr)
+	tmp, err := ioutil.ReadAll(io.LimitReader(gr, maxDecompressedDataLen+1))
 	if err != nil {
+		return dst
+	}
+	if len(tmp) > maxDecompressedDataLen {
 		return dst
 	}
 	dst = tmp

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/cheggaaa/pb v2.0.7+incompatible
+	github.com/creack/pty v1.1.18
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/eiannone/keyboard v0.0.0-20200508000154-caf4b762e807
 	github.com/fatih/color v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/cheggaaa/pb v2.0.7+incompatible h1:gLKifR1UkZ/kLkda5gC0K6c8g+jU2sINPtBeOiNlMhU=
 github.com/cheggaaa/pb v2.0.7+incompatible/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
+github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
+github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/protocol/http.go
+++ b/protocol/http.go
@@ -75,7 +75,7 @@ func (message *HTTPMessage) DeconstructHeader() {
 func (message *HTTPMessage) SendMessage() {
 	finalBuffer := append(message.HTTPHeader, message.HeaderBuffer...)
 	finalBuffer = append(finalBuffer, message.DataBuffer...)
-	message.RawMessage.Conn.Write(finalBuffer)
+	writeFull(message.RawMessage.Conn, finalBuffer)
 	// Don't forget to set both Buffer to nil!!!
 	message.HeaderBuffer = nil
 	message.DataBuffer = nil

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -64,6 +64,11 @@ const (
 	UPSTREAMREONLINE
 	SHUTDOWN
 	HEARTBEAT
+	TERMINALSTART
+	TERMINALREADY
+	TERMINALDATA
+	TERMINALRESIZE
+	TERMINALEXIT
 )
 
 const ADMIN_UUID = "IAMADMINXD"
@@ -174,6 +179,37 @@ type ShellResult struct {
 
 type ShellExit struct {
 	OK uint16
+}
+
+type TerminalStart struct {
+	Start   uint16
+	Session uint64
+	Cols    uint16
+	Rows    uint16
+}
+
+type TerminalReady struct {
+	Session  uint64
+	OK       uint16
+	ErrorLen uint64
+	Error    string
+}
+
+type TerminalData struct {
+	Session uint64
+	DataLen uint64
+	Data    []byte
+}
+
+type TerminalResize struct {
+	Session uint64
+	Cols    uint16
+	Rows    uint16
+}
+
+type TerminalExit struct {
+	Session uint64
+	OK      uint16
 }
 
 type ListenReq struct {

--- a/protocol/raw.go
+++ b/protocol/raw.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"reflect"
@@ -12,6 +13,11 @@ import (
 )
 
 type RawProto struct{}
+
+const (
+	maxRouteLen = 64 * 1024
+	maxDataLen  = 64 * 1024 * 1024
+)
 
 type RawMessage struct {
 	// Essential component to apply a Message
@@ -132,6 +138,9 @@ func (message *RawMessage) DeconstructData() (*Header, interface{}, error) {
 		return header, nil, err
 	}
 	header.RouteLen = binary.BigEndian.Uint32(routeLenBuf)
+	if header.RouteLen > maxRouteLen {
+		return header, nil, fmt.Errorf("route too large: %d", header.RouteLen)
+	}
 
 	routeBuf := make([]byte, header.RouteLen)
 	_, err = io.ReadFull(message.Conn, routeBuf)
@@ -145,6 +154,9 @@ func (message *RawMessage) DeconstructData() (*Header, interface{}, error) {
 		return header, nil, err
 	}
 	header.DataLen = binary.BigEndian.Uint64(dataLenBuf)
+	if header.DataLen > maxDataLen {
+		return header, nil, fmt.Errorf("message data too large: %d", header.DataLen)
+	}
 
 	dataBuf := make([]byte, header.DataLen)
 	_, err = io.ReadFull(message.Conn, dataBuf)
@@ -184,6 +196,16 @@ func (message *RawMessage) DeconstructData() (*Header, interface{}, error) {
 		mess = new(ShellResult)
 	case SHELLEXIT:
 		mess = new(ShellExit)
+	case TERMINALSTART:
+		mess = new(TerminalStart)
+	case TERMINALREADY:
+		mess = new(TerminalReady)
+	case TERMINALDATA:
+		mess = new(TerminalData)
+	case TERMINALRESIZE:
+		mess = new(TerminalResize)
+	case TERMINALEXIT:
+		mess = new(TerminalExit)
 	case LISTENREQ:
 		mess = new(ListenReq)
 	case LISTENRES:
@@ -271,6 +293,9 @@ func (message *RawMessage) DeconstructData() (*Header, interface{}, error) {
 	case HEARTBEAT:
 		mess = new(HeartbeatMsg)
 	}
+	if mess == nil {
+		return header, nil, errors.New("unknown message type")
+	}
 
 	messType := reflect.TypeOf(mess).Elem()
 	messValue := reflect.ValueOf(mess).Elem()
@@ -294,16 +319,32 @@ func (message *RawMessage) DeconstructData() (*Header, interface{}, error) {
 			case uint64:
 				stringLen = stringLenTmp
 			}
-			field.SetString(string(dataBuf[ptr : ptr+stringLen]))
+			fieldData, err := readDataField(dataBuf, ptr, stringLen)
+			if err != nil {
+				return header, nil, err
+			}
+			field.SetString(string(fieldData))
 			ptr += stringLen
 		case uint16:
-			field.SetUint(uint64(binary.BigEndian.Uint16(dataBuf[ptr : ptr+2])))
+			fieldData, err := readDataField(dataBuf, ptr, 2)
+			if err != nil {
+				return header, nil, err
+			}
+			field.SetUint(uint64(binary.BigEndian.Uint16(fieldData)))
 			ptr += 2
 		case uint32:
-			field.SetUint(uint64(binary.BigEndian.Uint32(dataBuf[ptr : ptr+4])))
+			fieldData, err := readDataField(dataBuf, ptr, 4)
+			if err != nil {
+				return header, nil, err
+			}
+			field.SetUint(uint64(binary.BigEndian.Uint32(fieldData)))
 			ptr += 4
 		case uint64:
-			field.SetUint(uint64(binary.BigEndian.Uint64(dataBuf[ptr : ptr+8])))
+			fieldData, err := readDataField(dataBuf, ptr, 8)
+			if err != nil {
+				return header, nil, err
+			}
+			field.SetUint(uint64(binary.BigEndian.Uint64(fieldData)))
 			ptr += 8
 		case []byte:
 			tmp := messValue.FieldByName(messType.Field(i).Name + "Len")
@@ -316,7 +357,11 @@ func (message *RawMessage) DeconstructData() (*Header, interface{}, error) {
 			case uint64:
 				byteLen = byteLenTmp
 			}
-			field.SetBytes(dataBuf[ptr : ptr+byteLen])
+			fieldData, err := readDataField(dataBuf, ptr, byteLen)
+			if err != nil {
+				return header, nil, err
+			}
+			field.SetBytes(fieldData)
 			ptr += byteLen
 		default:
 			return header, nil, errors.New("unknown error")
@@ -326,12 +371,29 @@ func (message *RawMessage) DeconstructData() (*Header, interface{}, error) {
 	return header, mess, nil
 }
 
+func readDataField(data []byte, offset uint64, length uint64) ([]byte, error) {
+	if length > uint64(len(data)) || offset > uint64(len(data))-length {
+		return nil, errors.New("malformed message data")
+	}
+	return data[offset : offset+length], nil
+}
+
 func (message *RawMessage) DeconstructSuffix() {}
 
 func (message *RawMessage) SendMessage() {
 	finalBuffer := append(message.HeaderBuffer, message.DataBuffer...)
-	message.Conn.Write(finalBuffer)
+	writeFull(message.Conn, finalBuffer)
 	// Don't forget to set both Buffer to nil!!!
 	message.HeaderBuffer = nil
 	message.DataBuffer = nil
+}
+
+func writeFull(conn net.Conn, buf []byte) {
+	for len(buf) > 0 {
+		n, err := conn.Write(buf)
+		if err != nil || n <= 0 {
+			return
+		}
+		buf = buf[n:]
+	}
 }


### PR DESCRIPTION
 ## 说明

  之前 `shell` 使用普通管道实现，不是真正的终端环境，在一些交互场景下体验不太好，比如方向键、补全、全屏程序、终端控制字符等支持有限，而且不能滚动。涉及到一些交互式操作时，往往手动升级为交互式shell，比较不便。

  这个 PR 在保留原有 shell 实现的基础上，增加了一套基于 PTY/ConPTY 的交互式终端通道。支持时默认使用新的交互式 shell；不支持或启动失败时，会回退到原来的 shell 逻辑。

  ## 主要改动

  - 新增 Terminal Stream 相关协议消息，用于终端启动、数据传输、窗口大小变化和退出通知。
  - Linux/macOS/FreeBSD 下使用 PTY 启动交互式 shell。
  - Windows 下在系统支持 ConPTY 时使用 ConPTY 启动交互式 shell。
  - 目标端不支持或启动失败时，自动回退到原来的 shell。
  - 原来的 shell 保留为 `legacy_shell`，方便在网络较差或兼容性场景下手动使用。
  - Unix-like admin 侧支持窗口大小变化同步。
  - 对协议解包增加了一些边界检查，避免异常数据导致 panic。

  ## 兼容性

  - 原有 shell 逻辑没有移除。
  - 老版本 agent 不支持 Terminal Stream 时，会继续走原 shell。
  - Windows 旧系统不支持 ConPTY 时，会自动回退到原 shell。
  - 多级节点转发仍然走原有消息路由逻辑。

  ## 测试

  本地已测试：

  - `go test ./...`
  - `go vet ./...`
  - `make all`
  - admin/agent 本地连接后，新 shell 可正常启动和执行命令
  - `legacy_shell` 可正常使用
  - 新 shell 启动失败时可以回退到原 shell
  - go1.26.1 linux/amd64下，与未修改前相比，总体体积增加约0.5%